### PR TITLE
Add save-only download mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ docker compose down
 - **`/start`** – Welcomes you and gives a brief introduction.  
 - **`/help`** – Shows detailed instructions and examples.  
 - **`/dl <post_URL>`** or simply paste a Telegram post link – Fetch photos, videos, audio, or documents from that post.  
+- **`/save <post_URL>`** – Download the file to the NAS and keep it in `downloads/` without sending it back into the chat.  
 - **`/bdl <start_link> <end_link>`** – Batch-download a range of posts in one go.  
 
   > 💡 Example: `/bdl https://t.me/mychannel/100 https://t.me/mychannel/120`  

--- a/USAGE.md
+++ b/USAGE.md
@@ -64,6 +64,11 @@ docker compose logs -f
 /dl https://t.me/c/123456789/10
 ```
 
+**Save only on the NAS:**
+```
+/save https://t.me/c/123456789/10
+```
+
 **Batch range:**
 ```
 /bdl https://t.me/c/123456789/3 https://t.me/c/123456789/2598
@@ -139,4 +144,3 @@ Telegram will ask you to wait (e.g., “wait 2500 seconds”).
 1) `docker compose down`
 2) `docker compose up -d --build --remove-orphans`
 3) `docker compose logs -f`
-

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -131,11 +131,21 @@ def progressArgs(action: str, progress_message, start_time):
 
 
 async def send_media(
-    bot, message, media_path, media_type, caption, progress_message, start_time
+    bot,
+    message,
+    media_path,
+    media_type,
+    caption,
+    progress_message,
+    start_time,
+    send_to_chat: bool = True,
 ):
     file_size = os.path.getsize(media_path)
 
     if not await fileSizeLimit(file_size, message, "upload"):
+        return
+
+    if not send_to_chat:
         return
 
     progress_args = progressArgs("📥 Uploading Progress", progress_message, start_time)
@@ -210,7 +220,7 @@ async def send_media(
             raise
 
 
-async def download_single_media(msg, progress_message, start_time):
+async def download_single_media(msg, progress_message, start_time, return_media_obj=True):
     for attempt in range(2):
         try:
             media_path = await msg.download(
@@ -225,13 +235,17 @@ async def download_single_media(msg, progress_message, start_time):
             )
 
             if msg.photo:
-                return ("success", media_path, InputMediaPhoto(media=media_path, caption=parsed_caption))
+                media_obj = InputMediaPhoto(media=media_path, caption=parsed_caption)
+                return ("success", media_path, media_obj if return_media_obj else None)
             if msg.video:
-                return ("success", media_path, InputMediaVideo(media=media_path, caption=parsed_caption))
+                media_obj = InputMediaVideo(media=media_path, caption=parsed_caption)
+                return ("success", media_path, media_obj if return_media_obj else None)
             if msg.document:
-                return ("success", media_path, InputMediaDocument(media=media_path, caption=parsed_caption))
+                media_obj = InputMediaDocument(media=media_path, caption=parsed_caption)
+                return ("success", media_path, media_obj if return_media_obj else None)
             if msg.audio:
-                return ("success", media_path, InputMediaAudio(media=media_path, caption=parsed_caption))
+                media_obj = InputMediaAudio(media=media_path, caption=parsed_caption)
+                return ("success", media_path, media_obj if return_media_obj else None)
 
         except FloodWait as e:
             wait_s = int(getattr(e, "value", 0) or 0)
@@ -247,7 +261,7 @@ async def download_single_media(msg, progress_message, start_time):
     return ("skip", None, None)
 
 
-async def processMediaGroup(chat_message, bot, message):
+async def processMediaGroup(chat_message, bot, message, save_only: bool = False):
     media_group_messages = await chat_message.get_media_group()
     valid_media = []
     temp_paths = []
@@ -262,7 +276,14 @@ async def processMediaGroup(chat_message, bot, message):
     download_tasks = []
     for msg in media_group_messages:
         if msg.photo or msg.video or msg.document or msg.audio:
-            download_tasks.append(download_single_media(msg, progress_message, start_time))
+            download_tasks.append(
+                download_single_media(
+                    msg,
+                    progress_message,
+                    start_time,
+                    return_media_obj=not save_only,
+                )
+            )
 
     results = await asyncio.gather(*download_tasks, return_exceptions=True)
 
@@ -272,13 +293,22 @@ async def processMediaGroup(chat_message, bot, message):
             continue
 
         status, media_path, media_obj = result
-        if status == "success" and media_path and media_obj:
+        if status == "success" and media_path:
             temp_paths.append(media_path)
-            valid_media.append(media_obj)
+            if media_obj:
+                valid_media.append(media_obj)
         elif status == "error" and media_path:
             invalid_paths.append(media_path)
 
     LOGGER(__name__).info(f"Valid media count: {len(valid_media)}")
+
+    if save_only:
+        for path in invalid_paths:
+            cleanup_download(path)
+        await progress_message.edit(
+            f"✅ Saved `{len(temp_paths)}` file(s) on the server."
+        )
+        return True
 
     if valid_media:
         try:

--- a/main.py
+++ b/main.py
@@ -76,6 +76,7 @@ async def start(_, message: Message):
         "👋 **Welcome to Media Downloader Bot!**\n\n"
         "I can grab photos, videos, audio, and documents from any Telegram post.\n"
         "Just send me a link (paste it directly or use `/dl <link>`),\n"
+        "or use `/save <link>` to keep the file only on the server.\n"
         "or reply to a message with `/dl`.\n\n"
         "ℹ️ Use `/help` to view all commands and examples.\n"
         "🔒 Make sure the user client is part of the chat.\n\n"
@@ -94,6 +95,8 @@ async def help_command(_, message: Message):
         "💡 **Media Downloader Bot Help**\n\n"
         "➤ **Download Media**\n"
         "   – Send `/dl <post_URL>` **or** just paste a Telegram post link to fetch photos, videos, audio, or documents.\n\n"
+        "➤ **Save Only**\n"
+        "   – Send `/save <post_URL>` to download the file to the NAS and keep it in `downloads/` without sending it back into the chat.\n\n"
         "➤ **Batch Download**\n"
         "   – Send `/bdl start_link end_link` to grab a series of posts in one go.\n"
         "     💡 Example: `/bdl https://t.me/mychannel/100 https://t.me/mychannel/120`\n"
@@ -134,7 +137,7 @@ async def cleanup_storage(_, message: Message):
         return await message.reply("❌ **Cleanup failed.** Check logs for details.")
 
 
-async def handle_download(bot: Client, message: Message, post_url: str):
+async def handle_download(bot: Client, message: Message, post_url: str, save_only: bool = False):
     async with download_semaphore:
         if "?" in post_url:
             post_url = post_url.split("?", 1)[0]
@@ -154,10 +157,11 @@ async def handle_download(bot: Client, message: Message, post_url: str):
                     else chat_message.audio.file_size
                 )
 
-                if not await fileSizeLimit(
-                    file_size, message, "download", user.me.is_premium
-                ):
-                    return
+                if not save_only:
+                    if not await fileSizeLimit(
+                        file_size, message, "download", user.me.is_premium
+                    ):
+                        return
 
             parsed_caption = await get_parsed_msg(
                 chat_message.caption or "", chat_message.caption_entities
@@ -167,7 +171,12 @@ async def handle_download(bot: Client, message: Message, post_url: str):
             )
 
             if chat_message.media_group_id:
-                if not await processMediaGroup(chat_message, bot, message):
+                if not await processMediaGroup(
+                    chat_message,
+                    bot,
+                    message,
+                    save_only=save_only,
+                ):
                     await message.reply(
                         "**Could not extract any valid media from the media group.**"
                     )
@@ -220,18 +229,22 @@ async def handle_download(bot: Client, message: Message, post_url: str):
                     if chat_message.audio
                     else "document"
                 )
-                await send_media(
-                    bot,
-                    message,
-                    media_path,
-                    media_type,
-                    parsed_caption,
-                    progress_message,
-                    start_time,
-                )
-
-                cleanup_download(media_path)
-                await progress_message.delete()
+                if save_only:
+                    await progress_message.edit(
+                        f"✅ **Saved on server:** `{media_path}`"
+                    )
+                else:
+                    await send_media(
+                        bot,
+                        message,
+                        media_path,
+                        media_type,
+                        parsed_caption,
+                        progress_message,
+                        start_time,
+                    )
+                    cleanup_download(media_path)
+                    await progress_message.delete()
 
             elif chat_message.text or chat_message.caption:
                 await message.reply(parsed_text or parsed_caption)
@@ -260,6 +273,16 @@ async def download_media(bot: Client, message: Message):
 
     post_url = message.command[1]
     await track_task(handle_download(bot, message, post_url))
+
+
+@bot.on_message(filters.command("save") & filters.private)
+async def save_media(bot: Client, message: Message):
+    if len(message.command) < 2:
+        await message.reply("**Provide a post URL after the /save command.**")
+        return
+
+    post_url = message.command[1]
+    await track_task(handle_download(bot, message, post_url, save_only=True))
 
 
 @bot.on_message(filters.command("bdl") & filters.private)


### PR DESCRIPTION
### What changed

This PR adds a new `/save` command for downloading media from Telegram posts to the server without sending the file back to the chat.

### Behavior

- `/dl <link>` keeps the current behavior and uploads the downloaded file back to the chat
- `/save <link>` stores the file locally in `downloads/`
- `/save` only sends a short confirmation message in chat

### Notes

This only affects the save flow. The existing `/dl` flow stays unchanged.